### PR TITLE
Fix unicode issue

### DIFF
--- a/location_field/widgets.py
+++ b/location_field/widgets.py
@@ -10,7 +10,7 @@ class LocationWidget(widgets.TextInput):
 
     def render(self, name, value, attrs=None):
         if value is not None:
-            if type(value) == str:
+            if isinstance(value, basestring):
                 lat, lng = value.split(',')
             else:
                 lng = value.x


### PR DESCRIPTION
## Environment details

Python version: 2.7.3
Django version: 1.5.1
Django Location Field version: 84718c64e039c4ca2974b62e220b60b6db74cf12 (latest master checkout)
## Problem

Currently the form explodes when I click save with the following error:

``` python
  File "/home/vagrant/.virtualenvs/fooo/local/lib/python2.7/site-packages/django/forms/forms.py", line 458, in as_widget
    return widget.render(name, self.value(), attrs=attrs)
  File "/home/vagrant/.virtualenvs/fooo/src/location-field/location_field/widgets.py", line 17, in render
    lng = value.x
AttributeError: 'unicode' object has no attribute 'x'
```

checkout from master)

The problem is that code only check for `str` type. I've modified to correctly check if a value is str / unicode using [basestring](http://docs.python.org/2/library/functions.html#basestring) check.
