### PR TITLE
Load Google Maps JavaScript file in the LocationWidget from a https:// url

### DIFF
--- a/location_field/widgets.py
+++ b/location_field/widgets.py
@@ -48,7 +48,8 @@ class LocationWidget(widgets.TextInput):
         return mark_safe(text_input + map_div % {'name': name})
 
     class Media:
+        # Use schemaless URL so it works with both, http and https websites
         js = (
-            'https://maps.google.com/maps/api/js?sensor=false',
+            '//maps.google.com/maps/api/js?sensor=false',
             '/location_field/media/form.js',
         )


### PR DESCRIPTION
## Environment details

Python version: 2.7.3
Django version: 1.5.1
Django Location Field version: 46c516df3998292ef5758383cfa5651366b2f15c (latest master checkout)
## Problem

Currently if you serve a website over a secure connection (https) Google Maps JavaScript file won't load in modern browsers (e.g. Chrome), because `LocationWidget` loads file from a non-secure version of the website.

I've modified the widget to always load JavaScript file from https URL, because loading https on http works fine, but it doesn't work in the opposite direction in modern browsers (which is a good and right behavior imo).
## References
- http://googleonlinesecurity.blogspot.com/2011/06/trying-to-end-mixed-scripting.html
