### PR TITLE
Improve behaviour when user manually changes location field

### DIFF
--- a/location_field/static/location_field/js/form.js
+++ b/location_field/static/location_field/js/form.js
@@ -92,14 +92,13 @@
                     f.keyup(cb);
             });
 
-            location_coordinate.keyup(function(){
+            location_coordinate.focusout(function(){
                 if (no_change) return;
                 var latlng = jQuery(this).val().split(/,/);
                 if (latlng.length < 2) return;
                 var latlng = new google.maps.LatLng(latlng[0], latlng[1]);
-                geocode_reverse(latlng, function(l){
-                    location_coordinate.val(l.lat()+','+l.lng());
-                });
+                location_map.panTo(latlng)
+                marker.setPosition(latlng)
             });
 
             function placeMarker(location) {


### PR DESCRIPTION
Hi. I'm using this field in my project, it's very good, thanks. Only one thing: I think that the current behavior when the user directly type the coordinates in the location input is not very useful. I find three problems:
- When the user types in the location coordinate field, at each keystroke a geocoding query is launched, and then the whole field contents is replaced. This make very uncomfortable to type a complete coordinates in the field.
- If there are many quick keypresses, many queries are launched simultaneously, and some times this cause javascript crashes.
- I don't think it makes much sense to reverse geocode the coordinates. If the user is typing them directly in the field, is because she knows them in advance (e.g. copying them from other place), so its better to leave them untouched.

So i have changed it to use the "focus out" event (so that the map changes only when exiting the field) and to not do reverse geocoding. It seems much more useful for me (and my users). What do you think?
