### PR TITLE
consistent jQuery usage

### DIFF
--- a/location_field/static/location_field/js/form.js
+++ b/location_field/static/location_field/js/form.js
@@ -348,7 +348,7 @@
         $.locationField(pluginOptions).render();
     });
 
-}($ || django.jQuery);
+}(jQuery || django.jQuery);
 
 
 var SequentialLoader = function() {


### PR DESCRIPTION
There were (jQuery || django.jQuery) and ($ || django.jQuery). This caused an js error ".livequery is not a function" in some cases. 
