### PR TITLE
Fix a bug: zoom is not applied to model fields.

### DIFF
--- a/location_field/models/base.py
+++ b/location_field/models/base.py
@@ -1,7 +1,7 @@
 class BaseLocationField(object):
     def __init__(self, **kwargs):
         self._based_fields = kwargs.pop('based_fields', [])
-        self._zoom = kwargs.pop('zoom', 2)
+        self._zoom = kwargs.get('zoom')
 
     def formfield(self, **kwargs):
         return super(BaseLocationField, self).formfield(

--- a/location_field/widgets.py
+++ b/location_field/widgets.py
@@ -17,6 +17,9 @@ class LocationWidget(widgets.TextInput):
             'based_fields': kwargs.pop('based_fields'),
         }
 
+        if kwargs.get('zoom'):
+            self.options['map.zoom'] = kwargs.get('zoom')
+
         super(LocationWidget, self).__init__(attrs)
 
     def render(self, name, value, attrs=None):


### PR DESCRIPTION
This is the example on project's Readme:

```py
from django.db import models
from location_field.models.plain import PlainLocationField

class Place(models.Model):
    city = models.CharField(max_length=255)
    location = PlainLocationField(based_fields=['city'], zoom=7)
```

But `zoom=7` is ignored and is not applied to map. This PR solves this issue.

"zoom" field passed to model fields LocationField and PlainLocationField will be applied to map. And if "zoom" is not passed to model field, it uses "map.zoom" from global settings.