### PR TITLE
Make geocoding respective to all values of the based fields

### DIFF
--- a/location_field/static/location_field/js/form.js
+++ b/location_field/static/location_field/js/form.js
@@ -282,16 +282,21 @@
 
             _watchBasedFields: function(map, marker) {
                 var self = this,
+                    basedFields = this.options.basedFields,
                     onchangeTimer,
                     onchange = function() {
-                        var value = $(this).val();
+                        var values = basedFields.map(function() {
+                            var value = $(this).val();
+                            return value === '' ? null : value;
+                        });
+                        var address = values.toArray().join(', ');
                         clearTimeout(onchangeTimer);
                         onchangeTimer = setTimeout(function(){
-                            self.search(map, marker, value);
+                            self.search(map, marker, address);
                         }, 300);
                     };
 
-                this.options.basedFields.each(function(){
+                basedFields.each(function(){
                     var el = $(this);
 
                     if (el.is('select'))


### PR DESCRIPTION
This patch makes location field to be based on all the `based fields` instead of the last edited single value.
It's useful when you have more than one fields for the address.
```python
based_fields=['address', 'city', 'state', 'zip_code', 'country']
```