### PR TITLE
Always prefix based fields with form prefix

### DIFF
--- a/location_field/static/location_field/js/form.js
+++ b/location_field/static/location_field/js/form.js
@@ -505,8 +505,12 @@ var SequentialLoader = function() {
             prefixNumber = name.match(/-(\d+)-/)[1];
         } catch (e) {}
 
-        if (prefixNumber != undefined && options.field_options.prefix) {
-            var prefix = options.field_options.prefix.replace(/__prefix__/, prefixNumber);
+        if (options.field_options.prefix) {
+            var prefix = options.field_options.prefix;
+
+            if (prefixNumber != null) {
+                prefix = prefix.replace(/__prefix__/, prefixNumber);
+            }
 
             basedFields = basedFields.map(function(n){
                 return prefix + n


### PR DESCRIPTION
Currently, the form prefix is only set if there is a number inside the location field's name. If a form has a prefix but is not an inline formset for example, this prefix will not be considered and based fields will not be retrieved. This fixes it by always prefix based fields with the form prefix if it is defined.