### PR TITLE
Do not pass if input field is hidden

### DIFF
--- a/location_field/static/location_field/js/form.js
+++ b/location_field/static/location_field/js/form.js
@@ -466,16 +466,13 @@ var SequentialLoader = function() {
     dataLocationFieldObserver(function(){
         var el = $(this);
 
-        if ( ! el.is(':visible'))
-            return;
-
         var name = el.attr('name'),
             options = el.data('location-field-options'),
             basedFields = options.field_options.based_fields,
             pluginOptions = {
                 id: 'map_' + name,
                 inputField: el,
-                latLng: el.parent().find(':text').val() || '0,0',
+                latLng: el.val() || '0,0',
                 suffix: options['search.suffix'],
                 path: options['resources.root_path'],
                 provider: options['map.provider'],


### PR DESCRIPTION
As we don't always want to show the GPS coordinates, this doesn't check input visibility to load - or not - the widget. For this to works, it also only relies on the element's value - and don't try to find another text input. I let you tell me if this can break some features, as currently I don't see any...