### PR TITLE
Accept a custom map provider in the options

### DIFF
--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -6,7 +6,9 @@ There are two kind of providers:
 Map providers
 -------------
 
-Map providers are used for rendering. For this we have three options:
+Map providers are used to define the tile layers displayed on the map.
+
+For this we have at first three options for predefined tile servers:
 
 - `Google <providers.html#google>`__
 - `Mapbox <providers.html#mapbox>`__
@@ -18,6 +20,20 @@ To set the map provider, use the ``map.provider`` property:
 
     LOCATION_FIELD = {
         'map.provider': 'google',
+    }
+
+As there are many `tile servers <https://wiki.openstreetmap.org/wiki/Tiles#Servers>`__,
+you can also set a custom one by defining a dict with at least the ``url`` property:
+
+.. code-block:: python
+
+    LOCATION_FIELD = {
+        'map.provider': {
+            'url': 'https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png',
+            'options': {
+                'maxZoom': '20',
+            },
+        },
     }
 
 

--- a/location_field/static/location_field/js/form.js
+++ b/location_field/static/location_field/js/form.js
@@ -95,7 +95,7 @@ var SequentialLoader = function() {
             render: function() {
                 this.$id = $('#' + this.options.id);
 
-                if ( ! this.providers.test(this.options.provider)) {
+                if ( ! this.providers.test(this.options.provider) && ! this.options.provider.url) {
                     this.error('render failed, invalid map provider: ' + this.options.provider);
                     return;
                 }
@@ -347,22 +347,28 @@ var SequentialLoader = function() {
             _getMap: function(mapOptions) {
                 var map = new L.Map(this.options.id, mapOptions), layer;
 
-                if (this.options.provider == 'google') {
+                if (this.options.provider === 'google') {
                     layer = new L.Google(this.options.providerOptions.google.mapType);
                 }
-                else if (this.options.provider == 'openstreetmap') {
+                else if (this.options.provider === 'openstreetmap') {
                     layer = new L.tileLayer(
                         '//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                             maxZoom: 18
                         });
                 }
-                else if (this.options.provider == 'mapbox') {
+                else if (this.options.provider === 'mapbox') {
                     layer = new L.tileLayer(
                         'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
                             maxZoom: 18,
                             accessToken: this.options.providerOptions.mapbox.access_token,
                             id: 'mapbox.streets'
                         });
+                }
+                else if (this.options.provider.url) {
+                    layer = new L.tileLayer(
+                        this.options.provider.url,
+                        this.options.provider.options || {}
+                    );
                 }
 
                 map.addLayer(layer);


### PR DESCRIPTION
This allows one to define its own tile server to use in case it is not in the predefined ones.