### PR TITLE
Exposed map widget width and height to settings

### DIFF
--- a/location_field/settings.py
+++ b/location_field/settings.py
@@ -5,6 +5,8 @@ LOCATION_FIELD_PATH = settings.STATIC_URL + 'location_field'
 LOCATION_FIELD = {
     'map.provider': 'google',
     'map.zoom': 13,
+    'map.widget_width': '500px',
+    'map.widget_height': '250px',
 
     'search.provider': 'google',
     'search.suffix': '',

--- a/location_field/templates/location_field/map_widget.html
+++ b/location_field/templates/location_field/map_widget.html
@@ -2,5 +2,5 @@
 <div class="map-widget" style="margin-top: 4px">
     <label></label>
 
-    <div id="map_{{field_name}}" style="width: 500px; height: 250px"></div>
+    <div id="map_{{field_name}}" style="width: {{map_widget_width}}; height: {{map_widget_height}}"></div>
 </div>

--- a/location_field/widgets.py
+++ b/location_field/widgets.py
@@ -55,7 +55,9 @@ class LocationWidget(widgets.TextInput):
 
         return render_to_string('location_field/map_widget.html', {
             'field_name': name,
-            'field_input': mark_safe(text_input)
+            'field_input': mark_safe(text_input),
+            'map_widget_width': self.options['map.widget_width'],
+            'map_widget_height': self.options['map.widget_height'],
         })
 
     @property


### PR DESCRIPTION
I've exposed the map widget attributes for the width and height in the settings, with the defaults set to the same as the original attrs.
This way, the user can override the attrs to set the width and height of the map view.