### PR TITLE
Remove livequery reference

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -37,7 +37,6 @@ These are the default settings:
         'resources.root_path': LOCATION_FIELD_PATH,
         'resources.media': {
             'js': (
-                LOCATION_FIELD_PATH + '/js/jquery.livequery.js',
                 LOCATION_FIELD_PATH + '/js/form.js',
             ),
         },


### PR DESCRIPTION
livequery was removed in https://github.com/caioariede/django-location-field/pull/114 but it is still referenced in the docs