### PR TITLE
Error in formfields documentation example

### DIFF
--- a/docs/source/formfields.rst
+++ b/docs/source/formfields.rst
@@ -54,7 +54,7 @@ Example:
     from django import forms
     from django.contrib.gis.geos import Point
 
-    from location_field.forms.plain import PlainLocationField
+    from location_field.forms.spatial import LocationField
 
 
     class Address(forms.Form):


### PR DESCRIPTION
The documentation for `location_field.forms.spatial.LocationField` had a copy-paste error.