### PR TITLE
fix: 🐛 fix nominatim address search

### DIFF
--- a/location_field/static/location_field/js/form.js
+++ b/location_field/static/location_field/js/form.js
@@ -196,7 +196,7 @@ var SequentialLoader = function() {
                 }
 
                 else if (this.options.searchProvider === 'nominatim') {
-                    var url = '//nominatim.openstreetmap.org/search/?format=json&q=' + address;
+                    var url = '//nominatim.openstreetmap.org/search?format=json&q=' + address;
 
                     var request = new XMLHttpRequest();
                     request.open('GET', url, true);


### PR DESCRIPTION
Due to a change in allowed URL formats, the nominatim OpenStreetMap search broke. This PR fixes it.

Background information
- Issue and discussion on Nominatim: https://github.com/osm-search/Nominatim/issues/3134
- Example of previous and now incorrect request and its result: https://nominatim.openstreetmap.org/search/?q=Augsburg&format=json